### PR TITLE
New branch with sleep function 

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -5,6 +5,7 @@
 from inspect import Parameter, Signature, signature
 
 import numpy as np
+import time
 
 # Can drop fallback once we rely on numpy>=2
 try:
@@ -5170,6 +5171,7 @@ def scale_height(temperature_bottom, temperature_top):
     <Quantity(7556.2307, 'meter')>
 
     """
+    time.sleep(2)
     t_bar = 0.5 * (temperature_bottom + temperature_top)
     return (mpconsts.nounit.Rd * t_bar) / mpconsts.nounit.g
 


### PR DESCRIPTION
This adds a sleep function to the scale_height function, so we expect the benchmarking PR to fail. 